### PR TITLE
fix: using new script for contracts deployment

### DIFF
--- a/request-contracts/Dockerfile
+++ b/request-contracts/Dockerfile
@@ -16,7 +16,7 @@ RUN yarn workspace @requestnetwork/types run build
 RUN yarn workspace @requestnetwork/currency run build
 WORKDIR /app/packages/smart-contracts
 RUN yarn build:sol
-RUN ncc build scripts/5_deploy-all.ts -o dist
+RUN ncc build scripts/test-deploy-all.ts -o dist
 
 FROM base
 ENV WEB3_URL=http://ganache:8545


### PR DESCRIPTION
I tried to build the request-contracts docker image, to include escrow, but it was failing with:
`
#20 [build 9/9] RUN ncc build scripts/5_deploy-all.ts -o dist
#0 0.133 Error: Cannot find module '/app/packages/smart-contracts/scripts/5_deploy-all.ts'
`
That 5_deploy-all.ts had been renamed to test-deploy-all, so that's my only change.

I couldn't build it locally for some other reason but I think it will work here.