### PR TITLE
fix(request-contracts): adapt image to new test-deploy-all script

### DIFF
--- a/request-contracts/Dockerfile
+++ b/request-contracts/Dockerfile
@@ -22,14 +22,31 @@ RUN yarn build:sol
 RUN mv tsconfig.json tsconfig.parent.json \
   && mv tsconfig.build.json tsconfig.json \
   && sed -i 's/"extends": ".\/tsconfig"/"extends": ".\/tsconfig.parent"/' tsconfig.json \
-  && ncc build scripts/test-deploy-all.ts -o dist
+  && ncc build scripts/test-deploy-all.ts \
+    -o dist \
+    -e hardhat \
+    -e ethers \
+    -e web3
+# We have to copy those files because of a dynamic import in the superfluid lib
+# see https://github.com/superfluid-finance/protocol-monorepo/blob/089010c1403a930c392435ec173dc37c76689cfc/packages/ethereum-contracts/scripts/libs/common.js#L292
+RUN cp -a /app/node_modules/@superfluid-finance/ethereum-contracts/scripts/libs dist/libs
+# This is to avoid running the detectTruffle() method which has even more dynamic imports
+RUN sed -i 's/truffleDetected: detectTruffle()/truffleDetected: false/' dist/libs/common.js
+RUN sed -i 's/detectTruffle,/detectTruffle: () => false,/' dist/libs/common.js
 
 FROM base
 ENV WEB3_URL=http://ganache:8545
-RUN npm install --production hardhat @nomiclabs/hardhat-ethers ethers
+RUN npm install --production \
+    hardhat@2.4.1 \
+    ethers@5.5.1 \
+    @nomiclabs/hardhat-ethers@2.0.2 \
+    # web3 is needed to deploy the superfluid protocol
+    web3@1.7.3 \
+    @nomiclabs/hardhat-web3@2.0.0
 COPY hardhat.config.js /app
 COPY --from=build /app/packages/smart-contracts/dist/index.js /app/deploy.js
-COPY --from=build /app/packages/smart-contracts/build /app/build
+COPY --from=build /app/packages/smart-contracts/dist/libs/ /app/libs/
+COPY --from=build /app/packages/smart-contracts/build/ /app/build/
 CMD dockerize \
     -wait "tcp://${WEB3_URL/http:\/\//}" \
     -timeout 60s \

--- a/request-contracts/Dockerfile
+++ b/request-contracts/Dockerfile
@@ -16,7 +16,13 @@ RUN yarn workspace @requestnetwork/types run build
 RUN yarn workspace @requestnetwork/currency run build
 WORKDIR /app/packages/smart-contracts
 RUN yarn build:sol
-RUN ncc build scripts/test-deploy-all.ts -o dist
+# NCC does not accept custom tsconfig files
+# so we need to rename tsconfig.build.json to -> tsconfig.json
+# see https://github.com/vercel/ncc/issues/385
+RUN mv tsconfig.json tsconfig.parent.json \
+  && mv tsconfig.build.json tsconfig.json \
+  && sed -i 's/"extends": ".\/tsconfig"/"extends": ".\/tsconfig.parent"/' tsconfig.json \
+  && ncc build scripts/test-deploy-all.ts -o dist
 
 FROM base
 ENV WEB3_URL=http://ganache:8545

--- a/request-contracts/hardhat.config.js
+++ b/request-contracts/hardhat.config.js
@@ -1,3 +1,5 @@
+require("@nomiclabs/hardhat-ethers");
+require("@nomiclabs/hardhat-web3");
 const { task } = require("hardhat/config");
 // import the compiled "deploy.ts"
 const deploy = require("./deploy").default;


### PR DESCRIPTION
https://app.asana.com/0/1202106549107986/1202331982981105/f

See https://github.com/RequestNetwork/docker-images/runs/6575623686?check_suite_focus=true for the failure on build.
The image has been tested and properly deploys all contracts on a private ganache node.