### PR TITLE
add python3 make and build-base as deps

### DIFF
--- a/request-contracts/Dockerfile
+++ b/request-contracts/Dockerfile
@@ -3,7 +3,7 @@ ARG TAG=master
 
 FROM node:${NODE_VERSION} AS base
 WORKDIR /app
-RUN apk add --no-cache git
+RUN apk add --no-cache git python3 make build-base
 RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing dockerize
 
 FROM base AS build

--- a/request-contracts/Dockerfile
+++ b/request-contracts/Dockerfile
@@ -3,7 +3,7 @@ ARG TAG=master
 
 FROM node:${NODE_VERSION} AS base
 WORKDIR /app
-RUN apk add --no-cache git python3 make build-base
+RUN apk add --no-cache git python3 build-base
 RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing dockerize
 
 FROM base AS build


### PR DESCRIPTION
In the `RUN yarn` stage, it fails because `node-gyp` failed to find `python3`. After I installed `python3`, it looks for `make`. After that, it throws an error that says something like a file is not found. Finally, I added `build-base` and it build the `request-contracts` Dockerfile