### PR TITLE
chore: move python3 and build-base to build for request contracts

### DIFF
--- a/request-contracts/Dockerfile
+++ b/request-contracts/Dockerfile
@@ -3,15 +3,15 @@ ARG TAG=master
 
 FROM node:${NODE_VERSION} AS base
 WORKDIR /app
+RUN apk add --no-cache git python3 build-base
 RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing dockerize
 
 FROM base AS build
 ARG TAG
-RUN apk add --no-cache git python3 build-base
 RUN yarn global add @vercel/ncc
 RUN git clone https://github.com/RequestNetwork/requestNetwork.git /app
 RUN git checkout ${TAG}
-RUN yarn
+RUN yarn --network-timeout 600000
 RUN yarn workspace @requestnetwork/types run build
 RUN yarn workspace @requestnetwork/currency run build
 WORKDIR /app/packages/smart-contracts

--- a/request-contracts/Dockerfile
+++ b/request-contracts/Dockerfile
@@ -3,11 +3,11 @@ ARG TAG=master
 
 FROM node:${NODE_VERSION} AS base
 WORKDIR /app
-RUN apk add --no-cache git python3 build-base
 RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing dockerize
 
 FROM base AS build
 ARG TAG
+RUN apk add --no-cache git python3 build-base
 RUN yarn global add @vercel/ncc
 RUN git clone https://github.com/RequestNetwork/requestNetwork.git /app
 RUN git checkout ${TAG}


### PR DESCRIPTION
Got `ESOCKETTIMEDOUT` from the actions. Probably due to the increasing container size because I install python and build-base in the `base` instead of `build`