### PR TITLE
refactor(request-node): cmd

### DIFF
--- a/request-node/Dockerfile
+++ b/request-node/Dockerfile
@@ -7,10 +7,11 @@ WORKDIR /node
 FROM base AS build
 ARG REQUEST_NODE_VERSION
 RUN apk add --no-cache git python3 build-base
-RUN npm install @requestnetwork/request-node@${REQUEST_NODE_VERSION}
+RUN npm install -g @requestnetwork/request-node@${REQUEST_NODE_VERSION}
 
 FROM base
 COPY --from=build /node /node
 ENV PORT 3000
 EXPOSE 3000
-CMD ["node", "/node/node_modules/@requestnetwork/request-node/dist/server.js"]
+
+CMD ["request-node"]


### PR DESCRIPTION
The entry file for request-node will change soon. Using the `bin` will avoid changing the path after release