### PR TITLE
fix: make default SUBGRAPH_NAME match RN's deployed storage subgraph

### DIFF
--- a/request-subgraph-storage/Dockerfile
+++ b/request-subgraph-storage/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:12-slim
 ENV SUBGRAPH_REPO=https://github.com/RequestNetwork/storage-subgraph.git
 ENV SUBGRAPH_BRANCH=main
 ENV SUBGRAPH_FILE=
-ENV SUBGRAPH_NAME=requestnetwork/request-storage
+ENV SUBGRAPH_NAME=request-network/request-storage
 
 ENV GRAPH_NODE=
 ENV IPFS_HOST=

--- a/request-subgraph-storage/Dockerfile
+++ b/request-subgraph-storage/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:12-slim
 ENV SUBGRAPH_REPO=https://github.com/RequestNetwork/storage-subgraph.git
 ENV SUBGRAPH_BRANCH=main
 ENV SUBGRAPH_FILE=
-ENV SUBGRAPH_NAME=request-network/request-storage
+ENV SUBGRAPH_NAME=RequestNetwork/request-storage
 
 ENV GRAPH_NODE=
 ENV IPFS_HOST=


### PR DESCRIPTION
# Changes

* This PR changes the default `SUBGRAPH_NAME` in the `request-subgraph-storage/Dockerfile` (which is only used by Request Network) to `RequestNetwork/request-storage` to match the storage subgraph deployed by Request Finance.

# Context

* The original storage subgraph deployed by Request Finance was named `RequestNetwork/request-storage`, as reflected in the [storage-subgraph README](https://github.com/RequestNetwork/storage-subgraph?tab=readme-ov-file#troubleshooting)
* When Request Network implemented its Graph Nodes, separate from Request Finance, the storage subgraph was deployed as `request-network/request-storage`.
* @MantisClone is in the process of renaming the storage subgraphs deployed by Request Network to `RequestNetwork/request-storage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
  - Updated environment variable `SUBGRAPH_NAME` in the Dockerfile to correct naming convention from `requestnetwork/request-storage` to `RequestNetwork/request-storage`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->