### PR TITLE
fix: path to download node v20.12.2

### DIFF
--- a/request-subgraph-storage/.resources/wget.txt
+++ b/request-subgraph-storage/.resources/wget.txt
@@ -1,1 +1,1 @@
-https://nodejs.org/dist/latest-v20.x/node-v20.12.2-linux-x64.tar.gz
+https://nodejs.org/dist/v20.12.2/node-v20.12.2-linux-x64.tar.gz


### PR DESCRIPTION
# Problem

The path for downloading Node v20 included `/latest/` and since v20.12.2 is no longer the latest version, it failed. 

# Changes

* fix: path to download node v20.12.2 to a URL that will always work

# Usage

This branch was used to deploy the storage subgraph on Staging. Need to merge to `main` before deploying to Production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated download URL to retrieve a specific version of Node.js (v20.12.2) for improved consistency and reproducibility.
  
- **Bug Fixes**
  - Corrected the URL format to ensure users receive the exact version instead of the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->