### PR TITLE
feat(request-ipfs): add option to enable relay service

### DIFF
--- a/request-ipfs/init_ipfs
+++ b/request-ipfs/init_ipfs
@@ -57,6 +57,10 @@ ipfs config Swarm.DisableBandwidthMetrics true --json
 ipfs config Swarm.ConnMgr.LowWater 50 --json
 ipfs config Swarm.ConnMgr.HighWater 1000 --json
 
+if [ "${ENABLE_RELAY_SERVICE}" = "true" ]; then
+  ipfs config Swarm.EnableRelayHop true --json
+fi
+
 # allow cors calls
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
 


### PR DESCRIPTION
This PR adds a new optional environment variable to the `request-ipfs` image: `ENABLE_RELAY_SERVICE` ; which activates the `Swarm.EnableRelayHop` option (see [doc here](https://github.com/ipfs/kubo/blob/master/docs/config.md#swarmenablerelayhop)).

This option has been renamed in later Kubo versions to `Swarm.RelayService.Enabled`. Thus, I chose to directly use the latest naming for the environment variable to avoid a breaking change later on once we support new Kubo versions.