### PR TITLE
fix: request-subgraph-storage README default SUBGRAPH_NAME

### DIFF
--- a/request-subgraph-storage/README.md
+++ b/request-subgraph-storage/README.md
@@ -9,7 +9,7 @@ subgraph data
 ENV SUBGRAPH_REPO=      # defaults to https://github.com/RequestNetwork/storage-subgraph.git
 ENV SUBGRAPH_BRANCH=    # defaults to main
 ENV SUBGRAPH_FILE=      # no default, typically subgraph-<chain>.yaml for above repo
-ENV SUBGRAPH_NAME=      # defaults to request-network/request-storage
+ENV SUBGRAPH_NAME=      # defaults to RequestNetwork/request-storage
 ```
 
 graph-node / ipfs


### PR DESCRIPTION
# Problem

Default `SUBGRAPH_NAME` is `RequestNetwork/request-storage` but README says it's `request-network/request-storage`

# Changes

* Fix the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the default value for the `SUBGRAPH_NAME` environment variable in the README for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->