### PR TITLE
chore: remove pull_request trigger from auto-project workflow

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -3,8 +3,6 @@ name: Auto Add to Project
 on:
   issues:
     types: [opened]
-  pull_request:
-    types: [opened]
 
 jobs:
   add-to-project:


### PR DESCRIPTION
The reusable workflow now only handles issues. Remove unnecessary pull_request trigger.

Fixes RequestNetwork/public-issues#151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified workflow automation to trigger on issue creation only, removing pull request event triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->